### PR TITLE
better error reporting for missing prerequisites

### DIFF
--- a/python/pioneer/netconf_console.py
+++ b/python/pioneer/netconf_console.py
@@ -251,7 +251,7 @@ class NetconfSSH(NetconfSSHLikeTransport):
             import paramiko
             self.paramiko = paramiko
         except:
-            self.iocb.abort("You must install the python ssh implementation paramiko\n" +
+            iocb.abort("You must install the python ssh implementation paramiko\n" +
                             "in order to use ssh.")
 
         NetconfSSHLikeTransport.__init__(self, iocb)

--- a/python/pioneer/op/netconf_op.py
+++ b/python/pioneer/op/netconf_op.py
@@ -71,7 +71,7 @@ class IoCb(object):
         self.trace.write(msg)
 
     def abort(self, msg):
-        raise Exception(msg)
+        raise ActionError({'error': msg})
 
     def create_trans(self, o):
         if o.proto == "ssh":


### PR DESCRIPTION
New users often forget to install some of the package prerequisites, especially Paramiko. In such case, Pioneer reports somewhat useless error message:
```
admin@ncs(config-device-DEV)# pioneer netconf hello
error Operation failed
admin@ncs(config-device-DEV)#
```
The change fixes that to
```
admin@ncs(config-device-DEV)# pioneer netconf hello
error You must install the python ssh implementation paramiko
in order to use ssh.
admin@ncs(config-device-DEV)#
```