### PR TITLE
pioneer: fixed encode/decode issue in Python 2 for unicode (no ascii)…

### DIFF
--- a/python/pioneer/op/netconf_op.py
+++ b/python/pioneer/op/netconf_op.py
@@ -196,8 +196,12 @@ class NetconfOp(base_op.BaseOp):
         netconf_console.main(args, iocb, self)
         self.debug("Returned from netconf_console")
 
-        xml_get_result = iocb.out.getvalue().decode()
-        stderr = iocb.err.getvalue().decode()
+        if sys.hexversion >= 0x03000000:
+            xml_get_result = iocb.out.getvalue().decode()
+            stderr = iocb.err.getvalue().decode()
+        else:
+            xml_get_result = iocb.out.getvalue()
+            stderr = iocb.err.getvalue()
 
         self.debug("Fetched:\n" + xml_get_result + "\n\n" + stderr)
         if stderr != "":

--- a/python/pioneer/op/yang_op.py
+++ b/python/pioneer/op/yang_op.py
@@ -102,6 +102,7 @@ class DownloadOp(YangOp):
                 xml_module = self.nc_perform('get-schema', method_opts=[str(modname)])
             except Exception as e:
                 self.progress_msg("-- download failed\n")
+                self.debug(traceback.format_exc())
                 result_str += "Failed {0} fetch error '{1}'\n".format(modname, repr(e))
                 failed_count += 1
             else:


### PR DESCRIPTION
… characters (DecodeError when downloading yang files with unicode characters),

encode/decode not used in Python2, netconf-console - some sync with NSO version

Signed-off-by: Michal Novak <micnovak@cisco.com>